### PR TITLE
allowing call of getLeaf() before makeTree() call

### DIFF
--- a/merkletools.js
+++ b/merkletools.js
@@ -83,10 +83,9 @@ var MerkleTools = function (treeOptions) {
 
   // Returns a leaf at the given index
   this.getLeaf = function (index) {
-    var leafLevelIndex = tree.levels.length - 1
-    if (index < 0 || index > tree.levels[leafLevelIndex].length - 1) return null // index is out of array bounds
+    if (index < 0 || index > tree.leaves.length - 1) return null // index is out of array bounds
 
-    return tree.levels[leafLevelIndex][index]
+    return tree.leaves[index]
   }
 
   // Returns the number of leaves added to the tree

--- a/test/main.js
+++ b/test/main.js
@@ -46,6 +46,58 @@ describe('Test basic functions', function () {
     })
   })
 
+  describe('getLeaf after running makeTree', function () {
+    var merkleTools = new MerkleTools()
+    merkleTools.addLeaves([
+      'a292780cc748697cb499fdcc8cb89d835609f11e502281dfe3f6690b1cc23dcb',
+      'cb4990b9a8936bbc137ddeb6dcab4620897b099a450ecdc5f3e86ef4b3a7135c'
+    ])
+    merkleTools.makeTree()
+
+    it('returned leaf should be in right spot', function () {
+      assert.equal(merkleTools.getLeaf(0).toString('hex'), 'a292780cc748697cb499fdcc8cb89d835609f11e502281dfe3f6690b1cc23dcb')
+    })
+  })
+
+  describe('getLeaf out of bounds returns null after running makeTree', function () {
+    var merkleTools = new MerkleTools()
+    merkleTools.addLeaves([
+      'a292780cc748697cb499fdcc8cb89d835609f11e502281dfe3f6690b1cc23dcb',
+      'cb4990b9a8936bbc137ddeb6dcab4620897b099a450ecdc5f3e86ef4b3a7135c'
+    ])
+    merkleTools.makeTree()
+
+    it('out of bounds leaf position returns null', function () {
+      assert.equal(merkleTools.getLeaf(3), null)
+      assert.equal(merkleTools.getLeaf(-1), null)
+    })
+  })
+
+  describe('getLeaf before running makeTree', function () {
+    var merkleTools = new MerkleTools()
+    merkleTools.addLeaves([
+      'a292780cc748697cb499fdcc8cb89d835609f11e502281dfe3f6690b1cc23dcb',
+      'cb4990b9a8936bbc137ddeb6dcab4620897b099a450ecdc5f3e86ef4b3a7135c'
+    ])
+
+    it('returned leaf should be in right spot', function () {
+      assert.equal(merkleTools.getLeaf(0).toString('hex'), 'a292780cc748697cb499fdcc8cb89d835609f11e502281dfe3f6690b1cc23dcb')
+    })
+  })
+
+  describe('getLeaf out of bounds returns null before running makeTree', function () {
+    var merkleTools = new MerkleTools()
+    merkleTools.addLeaves([
+      'a292780cc748697cb499fdcc8cb89d835609f11e502281dfe3f6690b1cc23dcb',
+      'cb4990b9a8936bbc137ddeb6dcab4620897b099a450ecdc5f3e86ef4b3a7135c'
+    ])
+
+    it('out of bounds leaf position returns null', function () {
+      assert.equal(merkleTools.getLeaf(3), null)
+      assert.equal(merkleTools.getLeaf(-1), null)
+    })
+  })
+
   describe('reset tree', function () {
     var merkleTools = new MerkleTools()
     merkleTools.addLeaves([


### PR DESCRIPTION
It was not possible to call getLeaf() before calling makeTree() - that call would result in an error as the  tree.levels array wasn't initialized yet.

The code overall doesn't discards the internal tree.leaves[] array so we can always go back to that array directly instead of finding it in the level hierarchy.

Adding test-cases as well.

If there is a reason why looking the levels is a better way that I missed: Then we can add a check and either look in the levels (if existing) or simply return from the leaves array (if makeTree() has not been called yet.

The code to look into both arrays one after the other would be like this (but the implementation in the PR is much simpler.

`this.getLeaf = function (index) {
    if (index < 0) return null // index is out of array bounds

    var leafLevelIndex = tree.levels.length - 1

    if(leafLevelIndex == -1 ){ // makeTree has not been called yet
      if(index > tree.leaves.length - 1) return null  // index is out of array bounds
      return tree.leaves[index]
    } else {
      if(index > tree.levels[leafLevelIndex].length - 1) return null  // index is out of array bounds      
      return tree.levels[leafLevelIndex][index]
    }
  }`