### PR TITLE
Fix/types: export method

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,29 @@ var treeOptions = {
 var merkleTools = new MerkleTools(treeOptions) // treeOptions is optional
 ```
 
+### Import with Typescript
+
+- If compiler is targeting CommonJS modules import assignment can be used:
+
+```ts
+import MerkleTools = require('merkle-tools');
+```
+
+- If you prefer to use default import or if compiler is not targeting CommonJS modules, enable `esModuleInterop`:
+
+```json
+// tsconfig.json
+{
+    "compilerOptions": {
+        "esModuleInterop": true
+    }
+}
+```
+
+```ts
+import MerkleTools from 'merkle-tools';
+```
+
 ## Methods
 
 ### addLeaf(value, doHash)

--- a/README.md
+++ b/README.md
@@ -36,10 +36,9 @@ var merkleTools = new MerkleTools(treeOptions) // treeOptions is optional
 import MerkleTools = require('merkle-tools');
 ```
 
-- If you prefer to use default import or if compiler is not targeting CommonJS modules, enable `esModuleInterop`:
+- If you prefer to use default import or if compiler is not targeting CommonJS modules, enable `esModuleInterop` on your tsconfig:
 
 ```json
-// tsconfig.json
 {
     "compilerOptions": {
         "esModuleInterop": true

--- a/merkletools.d.ts
+++ b/merkletools.d.ts
@@ -1,5 +1,5 @@
 declare module 'merkle-tools' {
-  export type Proof<T> = { left: T } | { right: T };
+  type Proof<T> = { left: T } | { right: T };
 
   class MerkleTree {
     constructor(options: { hashType: string });
@@ -23,5 +23,5 @@ declare module 'merkle-tools' {
     ): boolean;
   }
 
-  export default MerkleTree;
+  export = MerkleTree;
 }

--- a/merkletools.d.ts
+++ b/merkletools.d.ts
@@ -2,7 +2,7 @@ declare module 'merkle-tools' {
   type Proof<T> = { left: T } | { right: T };
 
   class MerkleTree {
-    constructor(options: { hashType: string });
+    constructor(options?: { hashType: string });
 
     getMerkleRoot(): Buffer | null;
     getProof(index: number): Proof<string>[] | null;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "js-sha3": "^0.8.0"
   },
   "devDependencies": {
+    "@types/node": "^18.11.12",
     "mocha": "^8.2.1"
   }
 }


### PR DESCRIPTION
Hi!
First of all thank you for the amazing job with the library.
It was exactly what I was looking for, Merkle Tree creation using the default Node Crypto module instead of another Javascript library to calculate the hashes. 

While trying to use the library on our Typescript project I could not find a way to import without Typescript complaining about the way that I was importing the library or getting runtime errors with the message `Module has no default export`.

Digging into the problem what I found is that it may have a mismatch between the library types and the library code itself.
The library is being exported using `module.exports = MerkleTools` and the type definition declares being exported as `export default MerkleTree`. I myself thought both were equivalents until 2 weeks ago, but Typescript `export default` is translated to a named export of Javascript like in `module.exports.default = MerkleTools`.

So right now when we do a `import MerkleTools from 'merkle-tools'` Typescript and the IDE accepts because the type is declared that way, but when you run the script you get a runtime error because actually there is no module.exports.default being exported.

To be able to use the library with Typescript I made a fix, I changed the type declaration to `export = MerkleTree` which matches the exports of the library.
Also I set treeOptions as optional like in the documentation and put a small How to Import with Typescript on Readme.

Note: while using `export =` on Typescript is like `module.exports =` on Javascript which means that we cannot export more than one thing at the same module. So I removed the export of Type Proof.
I don't know if this affect someone since Typescript can already infer the returned values of the merkletools methods.

If there is already a way to use the lib with Typescript without these changes, please let me know.
Thank you