### PR TITLE
Fix `validateProof()` `proof` argument type

### DIFF
--- a/merkletools.d.ts
+++ b/merkletools.d.ts
@@ -16,7 +16,7 @@ declare module 'merkle-tools' {
     makeTree(doubleHash?: boolean): void;
     makeBTCTree(doubleHash?: boolean): void;
     validateProof(
-      proof: Proof<string | Buffer>,
+      proof: readonly Proof<string | Buffer>[],
       targetHash: string | Buffer,
       merkleRoot: string | Buffer,
       doubleHash?: boolean,


### PR DESCRIPTION
`validateProof()` accepts an array of `Proof`s, not a single `Proof`.